### PR TITLE
Conditionally pass children to react.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,3 @@ script:
 branches:
   only:
     - master
-
-before_script:
-  - "export NODE_ENV=production"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+- Only pass wrapped children if children exist to pass prop type validation. (#27)
+
 ## [0.2.0] - 2017-11-10
 ### Updated
 - Rollup 0.51

--- a/src/wrappers/React.js
+++ b/src/wrappers/React.js
@@ -24,12 +24,19 @@ const makeReactContainer = Component => {
     }
 
     render () {
-      const { children, ...rest } = this.state
+      const {
+        children,
+        // Vue attaches an event handler, but it is missing an event name, so
+        // it ends up using an empty string. Prevent passing an empty string
+        // named prop to React.
+        '': _invoker,
+        ...rest
+      } = this.state
       const wrappedChildren = this.wrapVueChildren(children)
 
       return (
         <Component {...rest}>
-          <VueWrapper component={wrappedChildren} />
+          {children && <VueWrapper component={wrappedChildren} />}
         </Component>
       )
     }
@@ -44,12 +51,13 @@ export default {
   methods: {
     mountReactComponent (component) {
       const Component = makeReactContainer(component)
+      const children = this.$slots.default !== undefined ? { children: this.$slots.default } : {}
       ReactDOM.render(
         <Component
           {...this.$props.passedProps}
           {...this.$attrs}
           {...this.$listeners}
-          children={this.$slots.default}
+          {...children}
           ref={ref => (this.reactComponentRef = ref)}
         />,
         this.$refs.react
@@ -67,7 +75,11 @@ export default {
      * AFAIK, this is the only way to update children. It doesn't seem to be possible to watch
      * `$slots` or `$children`.
      */
-    this.reactComponentRef.setState({ children: this.$slots.default })
+    if (this.$slots.default !== undefined) {
+      this.reactComponentRef.setState({ children: this.$slots.default })
+    } else {
+      this.reactComponentRef.setState({ children: null })
+    }
   },
   inheritAttrs: false,
   watch: {

--- a/tests/fixtures/ReactChildlessComponent.js
+++ b/tests/fixtures/ReactChildlessComponent.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const versionedPropTypes = React.version < '15.6.0' ? React.PropTypes : PropTypes
+
+export default class ChildlessComponent extends React.Component {
+  render () {
+    return (
+      <div>
+        <span>{this.props.message}</span>
+        <button onClick={this.props.reset} />
+      </div>
+    )
+  }
+}
+
+ChildlessComponent.propTypes = {
+  message: versionedPropTypes.string,
+  reset: versionedPropTypes.func,
+  // this component does not allow children
+  children: versionedPropTypes.oneOf([undefined]), // eslint-disable-line react/no-unused-prop-types
+}

--- a/tests/wrappers/ReactWrapper-test.js
+++ b/tests/wrappers/ReactWrapper-test.js
@@ -3,6 +3,7 @@ import React from 'react'
 import { ReactWrapper } from '../../src'
 import PureFunctionalComponent from '../fixtures/ReactPureFunctionalComponent'
 import Component from '../fixtures/ReactComponent'
+import ChildlessComponent from '../fixtures/ReactChildlessComponent'
 import olderVueCompat from '../utils/olderVueCompat'
 
 const mockReset = jest.fn()
@@ -190,6 +191,42 @@ describe('ReactInVue', () => {
           </div></div></div></div>`
         )
       )
+    })
+
+    it('works with no children', () => {
+      const spy = jest.spyOn(console, 'error')
+
+      makeVueInstanceWithReactComponent(ChildlessComponent)
+      expect(document.body.innerHTML).toBe(
+        '<div><input><div><div><span>Message for React</span><button></button></div></div></div>'
+      )
+      expect(spy.mock.calls.length).toBe(0)
+
+      spy.mockReset()
+      spy.mockRestore()
+    })
+
+    it('raises underlying prop type errors with children in childless component', () => {
+      const spy = jest.spyOn(console, 'error')
+
+      makeVueInstanceWithReactComponent(ChildlessComponent, function (
+        createElement
+      ) {
+        return createElement('div', [
+          createElement(
+            'react',
+            olderVueCompat({ props: { component: this.component } }),
+            'child'
+          ),
+        ])
+      })
+      expect(document.body.innerHTML).toBe(
+        '<div><div><div><span></span><button></button></div></div></div>'
+      )
+      expect(spy.mock.calls.length).toBe(1)
+
+      spy.mockReset()
+      spy.mockRestore()
     })
   })
 })


### PR DESCRIPTION
This is a very cool library! Thanks for the work.

We're using a react library in Vue that has strict proptype definitions. When react proptypes are evaluated, always passing children can result in proptype warnings (ie if children are not expected). This makes passing children dependent on the children existing.