### PR TITLE
Fix passing children as props.

### DIFF
--- a/src/wrappers/React.js
+++ b/src/wrappers/React.js
@@ -19,7 +19,7 @@ const makeReactContainer = Component => {
 
     wrapVueChildren (children) {
       return {
-        render: createElement => createElement('div', children),
+        render: createElement => createElement('div', null, children),
       }
     }
 


### PR DESCRIPTION
As per [the docs](https://reactjs.org/docs/react-api.html#createelement) `createElement`'s  second argument is for props, not children.