### PR TITLE
Optimize React-in-Vue of immediate react children.

### DIFF
--- a/src/VuePlugin.js
+++ b/src/VuePlugin.js
@@ -4,6 +4,9 @@ import VueResolver from './resolvers/Vue'
 /**
  * This mixin automatically wraps all React components into Vue.
  */
+
+const reactRegistry = {}
+
 export default {
   install (Vue, options) {
     /**
@@ -13,15 +16,20 @@ export default {
     const originalComponentsMergeStrategy = Vue.config.optionMergeStrategies.components
     Vue.config.optionMergeStrategies.components = function (parent, ...args) {
       const mergedValue = originalComponentsMergeStrategy(parent, ...args)
+
       const wrappedComponents = mergedValue
-        ? Object.entries(mergedValue).reduce(
-            (acc, [k, v]) => ({
+        ? Object.entries(mergedValue).reduce((acc, [k, v]) => {
+            const components = {
               ...acc,
-              [k]: isReactComponent(v) ? VueResolver(v) : v,
-            }),
-            {}
-          )
+              [k]: isReactComponent(v) ? VueResolver(v, reactRegistry) : v
+            }
+            if (isReactComponent(v)) {
+              reactRegistry[k] = v
+            }
+            return components
+          }, {})
         : mergedValue
+
       return Object.assign(parent, wrappedComponents)
     }
   },

--- a/src/resolvers/Vue.js
+++ b/src/resolvers/Vue.js
@@ -1,6 +1,6 @@
 import { ReactWrapper } from '../'
 
-export default function VueResolver (component) {
+export default function VueResolver (component, reactRegistry) {
   return {
     components: { ReactWrapper },
     props: ['passedProps'],
@@ -11,6 +11,7 @@ export default function VueResolver (component) {
         {
           props: {
             component,
+            reactRegistry,
             passedProps: this.$props.passedProps,
           },
           attrs: this.$attrs,

--- a/src/wrappers/Vue.js
+++ b/src/wrappers/Vue.js
@@ -50,6 +50,10 @@ export default class VueContainer extends React.Component {
     this.vueInstance.$destroy()
   }
 
+  componentName() {
+    return `vuera-internal-component-name-${this.vueraComponentName}`
+  }
+
   /**
    * Creates and mounts the Vue instance.
    * NOTE: since we need to access the current instance of VueContainer, as well as the Vue instance
@@ -67,16 +71,16 @@ export default class VueContainer extends React.Component {
       data: props,
       render (createElement) {
         return createElement(
-          VUE_COMPONENT_NAME,
+          reactThisBinding.componentName(),
           {
-            props: this.$data,
+            props: this.$data
           },
           [wrapReactChildren(createElement, this.children)]
         )
       },
       components: {
-        [VUE_COMPONENT_NAME]: component,
-        'vuera-internal-react-wrapper': ReactWrapper,
+        [reactThisBinding.componentName()]: component,
+        'vuera-internal-react-wrapper': ReactWrapper
       },
     })
   }
@@ -87,7 +91,7 @@ export default class VueContainer extends React.Component {
     /**
      * Replace the component in the Vue instance and update it.
      */
-    this.vueInstance.$options.components[VUE_COMPONENT_NAME] = nextComponent
+    this.vueInstance.$options.components[this.componentName()] = nextComponent
     this.vueInstance.$forceUpdate()
   }
 


### PR DESCRIPTION
This is a proof of concept for handling a special case of React components as children of React components in Vue. It works by creating a registry of React components and then checking to see if components are parent/children. 

[Vue's built-in resolution](https://github.com/vuejs/vue/blob/05299610ea3e89ddbcfe4d8ede0c298223766423/src/core/vdom/create-element.js#L105) with [name checking](https://github.com/vuejs/vue/blob/19552a82a636910f4595937141557305ab5d434e/dist/vue.runtime.common.js#L1491) isn't available as a utility, so included similar code.

Ref: https://github.com/akxcv/vuera/issues/19.