### PR TITLE
Run ESLint on Travis instead of Hound

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 /dist/vuera*
+/coverage
 /node_modules
 /tests/fixtures/babel

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ install:
   - yarn install
   - yarn add -D react@$REACT_VERSION react-dom@$REACT_VERSION vue@$VUE_VERSION vue-template-compiler@$VUE_VERSION
 script:
+  - yarn lint
   - yarn run test:coverage -- --coverageReporters=lcov
   - cat ./coverage/lcov.info | yarn run coveralls
 


### PR DESCRIPTION
Hound CI has been problematic for a long time. I think it's time to switch to running ESLint on Travis.