### PR TITLE
fix: solve prop to state warning from react >= 16.5.0

### DIFF
--- a/src/wrappers/React.js
+++ b/src/wrappers/React.js
@@ -10,11 +10,13 @@ const makeReactContainer = Component => {
       super(props)
 
       /**
-       * We create a stateful component in order to attach a ref on it. We will use that ref to
-       * update component's state, which seems better than re-rendering the whole thing with
+       * We previously created a stateful component in order to attach a ref on it. We have used that ref to
+       * update component's state, which seemed better than re-rendering the whole thing with
        * ReactDOM.
+       * Since React 16.5.0 the above would have logged errors, so we continue to shallow copy props. See
+       * https://github.com/facebook/react/pull/11658
        */
-      this.state = props
+      this.state = { ...props }
     }
 
     wrapVueChildren (children) {


### PR DESCRIPTION
On a fresh install of all dependencies a setup like this will print annoying error messages from react DOM.

A fix should be making a shallow copy, as taken from the react issue tracker. I am not so confident about the consequences for this library and would rely on your guidance.

```html
<template>
  <div>
    <three :passed-props="passedProps" />
  </div>
</template>

<script>
import React from 'react'

class Three extends React.Component {
  render () {
    return (
      <div>
        React
      </div>
    )
  }
}

export default {
  name: 'HelloWorld',
  components: { three: Three },
  props: {
    msg: {
      type: String,
      required: true
    }
  },
  computed: {
    passedProps () {
      return {
        message: this.message,
        reset: this.reset
      }
    }
  }
}
</script>
```