### PR TITLE
 Recognise styled-components as React Components

### DIFF
--- a/dist/vuera.cjs.js
+++ b/dist/vuera.cjs.js
@@ -407,13 +407,15 @@ var ReactWrapper = {
 };
 
 function isReactComponent(component) {
-  if ((typeof component === 'undefined' ? 'undefined' : _typeof(component)) === 'object') {
+  if ((typeof component === 'undefined' ? 'undefined' : _typeof(component)) === 'object' && !isReactForwardReference(component)) {
     return false;
-  } else if (typeof component === 'function' && component.prototype && component.prototype.constructor.super && component.prototype.constructor.super.name.startsWith('Vue')) {
-    return false;
-  } else {
-    return true;
   }
+
+  return !(typeof component === 'function' && component.prototype && component.prototype.constructor.super && component.prototype.constructor.super.name.startsWith('Vue'));
+}
+
+function isReactForwardReference(component) {
+  return component.$$typeof && component.$$typeof.toString() === 'Symbol(react.forward_ref)';
 }
 
 function VueResolver$$1(component) {

--- a/dist/vuera.es.js
+++ b/dist/vuera.es.js
@@ -401,13 +401,15 @@ var ReactWrapper = {
 };
 
 function isReactComponent(component) {
-  if ((typeof component === 'undefined' ? 'undefined' : _typeof(component)) === 'object') {
+  if ((typeof component === 'undefined' ? 'undefined' : _typeof(component)) === 'object' && !isReactForwardReference(component)) {
     return false;
-  } else if (typeof component === 'function' && component.prototype && component.prototype.constructor.super && component.prototype.constructor.super.name.startsWith('Vue')) {
-    return false;
-  } else {
-    return true;
   }
+
+  return !(typeof component === 'function' && component.prototype && component.prototype.constructor.super && component.prototype.constructor.super.name.startsWith('Vue'));
+}
+
+function isReactForwardReference(component) {
+  return component.$$typeof && component.$$typeof.toString() === 'Symbol(react.forward_ref)';
 }
 
 function VueResolver$$1(component) {

--- a/dist/vuera.iife.js
+++ b/dist/vuera.iife.js
@@ -404,13 +404,15 @@ var ReactWrapper = {
 };
 
 function isReactComponent(component) {
-  if ((typeof component === 'undefined' ? 'undefined' : _typeof(component)) === 'object') {
+  if ((typeof component === 'undefined' ? 'undefined' : _typeof(component)) === 'object' && !isReactForwardReference(component)) {
     return false;
-  } else if (typeof component === 'function' && component.prototype && component.prototype.constructor.super && component.prototype.constructor.super.name.startsWith('Vue')) {
-    return false;
-  } else {
-    return true;
   }
+
+  return !(typeof component === 'function' && component.prototype && component.prototype.constructor.super && component.prototype.constructor.super.name.startsWith('Vue'));
+}
+
+function isReactForwardReference(component) {
+  return component.$$typeof && component.$$typeof.toString() === 'Symbol(react.forward_ref)';
 }
 
 function VueResolver$$1(component) {

--- a/src/utils/isReactComponent.js
+++ b/src/utils/isReactComponent.js
@@ -1,14 +1,16 @@
 export default function isReactComponent (component) {
-  if (typeof component === 'object') {
+  if (typeof component === 'object' && !isReactForwardReference(component)) {
     return false
-  } else if (
+  }
+
+  return !(
     typeof component === 'function' &&
     component.prototype &&
     component.prototype.constructor.super &&
     component.prototype.constructor.super.name.startsWith('Vue')
-  ) {
-    return false
-  } else {
-    return true
-  }
+  )
+}
+
+function isReactForwardReference (component) {
+  return component.$$typeof && component.$$typeof.toString() === 'Symbol(react.forward_ref)'
 }

--- a/tests/fixtures/StyledComponent.js
+++ b/tests/fixtures/StyledComponent.js
@@ -1,0 +1,14 @@
+export default {
+  $$typeof: Symbol('react.forward_ref'),
+  attrs: [],
+  componentStyle: {
+    rules: ['background: red;'],
+    isStatic: false,
+    componentId: 'sc-dnqmqq',
+    lastClassName: 'boyWDb',
+  },
+  displayName: 'styled.h3',
+  foldedComponentIds: [],
+  styledComponentId: 'sc-dnqmqq',
+  target: 'h3',
+}

--- a/tests/utils/isReactComponent-test.js
+++ b/tests/utils/isReactComponent-test.js
@@ -2,6 +2,7 @@ import isReactComponent from '../../src/utils/isReactComponent'
 import ReactComponent from '../fixtures/ReactComponent'
 import ReactPureFunctionalComponent from '../fixtures/ReactPureFunctionalComponent'
 import ReactFunctionalComponent from '../fixtures/ReactFunctionalComponent'
+import StyledComponent from '../fixtures/StyledComponent'
 import VueComponent from '../fixtures/VueComponent'
 import VueRegisteredComponent from '../fixtures/VueRegisteredComponent'
 import VueSingleFileComponent from '../fixtures/VueSingleFileComponent.vue'
@@ -11,6 +12,7 @@ describe('isReactComponent', () => {
     expect(isReactComponent(ReactComponent)).toBe(true)
     expect(isReactComponent(ReactPureFunctionalComponent)).toBe(true)
     expect(isReactComponent(ReactFunctionalComponent)).toBe(true)
+    expect(isReactComponent(StyledComponent)).toBe(true)
   })
 
   it('returns false for Vue components', () => {


### PR DESCRIPTION
Currently styled-components are not being recognised as React components since they are an object wrapper around a React component.

The isReactComponent util function will now also look at the styledComponentId property since it's not present in the vue-styled-components implementation (so it won't mistakenly try to render a Vue styled-component as a React component).

Fixes #68 