### PR TITLE
A fix for vue class syntax components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 /coverage
 /node_modules
 /yarn-error.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.idea
 /coverage
 /node_modules
 /yarn-error.log

--- a/dist/vuera.cjs.js
+++ b/dist/vuera.cjs.js
@@ -411,7 +411,7 @@ function isReactComponent(component) {
     return false;
   }
 
-  return !(typeof component === 'function' && component.prototype && component.prototype.constructor.super && component.prototype.constructor.super.name.startsWith('Vue'));
+  return !(typeof component === 'function' && component.prototype && component.prototype.constructor.super && component.prototype.constructor.super.isVue);
 }
 
 function isReactForwardReference(component) {
@@ -461,6 +461,7 @@ var VuePlugin = {
       }, {}) : mergedValue;
       return Object.assign(parent, wrappedComponents);
     };
+    Vue$$1.prototype.constructor.isVue = true;
   }
 };
 

--- a/dist/vuera.es.js
+++ b/dist/vuera.es.js
@@ -405,7 +405,7 @@ function isReactComponent(component) {
     return false;
   }
 
-  return !(typeof component === 'function' && component.prototype && component.prototype.constructor.super && component.prototype.constructor.super.name.startsWith('Vue'));
+  return !(typeof component === 'function' && component.prototype && component.prototype.constructor.super && component.prototype.constructor.super.isVue);
 }
 
 function isReactForwardReference(component) {
@@ -455,6 +455,7 @@ var VuePlugin = {
       }, {}) : mergedValue;
       return Object.assign(parent, wrappedComponents);
     };
+    Vue$$1.prototype.constructor.isVue = true;
   }
 };
 

--- a/dist/vuera.iife.js
+++ b/dist/vuera.iife.js
@@ -408,7 +408,7 @@ function isReactComponent(component) {
     return false;
   }
 
-  return !(typeof component === 'function' && component.prototype && component.prototype.constructor.super && component.prototype.constructor.super.name.startsWith('Vue'));
+  return !(typeof component === 'function' && component.prototype && component.prototype.constructor.super && component.prototype.constructor.super.isVue);
 }
 
 function isReactForwardReference(component) {
@@ -458,6 +458,7 @@ var VuePlugin = {
       }, {}) : mergedValue;
       return Object.assign(parent, wrappedComponents);
     };
+    Vue$$1.prototype.constructor.isVue = true;
   }
 };
 

--- a/src/VuePlugin.js
+++ b/src/VuePlugin.js
@@ -24,6 +24,6 @@ export default {
         : mergedValue
       return Object.assign(parent, wrappedComponents)
     }
-    Vue.prototype.constructor.isVue = true;
+    Vue.prototype.constructor.isVue = true
   },
 }

--- a/src/VuePlugin.js
+++ b/src/VuePlugin.js
@@ -24,5 +24,6 @@ export default {
         : mergedValue
       return Object.assign(parent, wrappedComponents)
     }
+    Vue.prototype.constructor.isVue = true;
   },
 }

--- a/src/utils/isReactComponent.js
+++ b/src/utils/isReactComponent.js
@@ -7,7 +7,7 @@ export default function isReactComponent (component) {
     typeof component === 'function' &&
     component.prototype &&
     component.prototype.constructor.super &&
-    component.prototype.constructor.super.name.startsWith('Vue')
+    component.prototype.constructor.super.isVue
   )
 }
 

--- a/tests/__setup__.js
+++ b/tests/__setup__.js
@@ -6,3 +6,4 @@ global.normalizeHTMLString = function normalizeHTMLString (string) {
 }
 
 Vue.config.productionTip = false
+Vue.prototype.constructor.isVue = true


### PR DESCRIPTION
I also ran in into #48, unknowingly that there is already an issue for it i came to the same conclusion as @stlbucket.

It would be great if this issue would be fixed, i added a property to the prototype to see if a component is a vue component to make sure that there are no corner cases. I know it is not the cleanest solution but it works.

An alternative fix, without touching the prototype, would be to see if the `version` property exists, react doesn't expose this but vue does, however that may break at any point in time, especially when Vue 3.0 is released