### PR TITLE
fix isReactComponent returning true for blank input

### DIFF
--- a/dist/vuera.cjs.js
+++ b/dist/vuera.cjs.js
@@ -407,6 +407,7 @@ var ReactWrapper = {
 };
 
 function isReactComponent(component) {
+  if (!component) return false;
   if ((typeof component === 'undefined' ? 'undefined' : _typeof(component)) === 'object' && !isReactForwardReference(component)) {
     return false;
   }

--- a/dist/vuera.es.js
+++ b/dist/vuera.es.js
@@ -401,6 +401,7 @@ var ReactWrapper = {
 };
 
 function isReactComponent(component) {
+  if (!component) return false;
   if ((typeof component === 'undefined' ? 'undefined' : _typeof(component)) === 'object' && !isReactForwardReference(component)) {
     return false;
   }

--- a/dist/vuera.iife.js
+++ b/dist/vuera.iife.js
@@ -404,6 +404,7 @@ var ReactWrapper = {
 };
 
 function isReactComponent(component) {
+  if (!component) return false;
   if ((typeof component === 'undefined' ? 'undefined' : _typeof(component)) === 'object' && !isReactForwardReference(component)) {
     return false;
   }

--- a/src/utils/isReactComponent.js
+++ b/src/utils/isReactComponent.js
@@ -1,4 +1,5 @@
 export default function isReactComponent (component) {
+  if (!component) return false
   if (typeof component === 'object' && !isReactForwardReference(component)) {
     return false
   }

--- a/tests/utils/isReactComponent-test.js
+++ b/tests/utils/isReactComponent-test.js
@@ -20,4 +20,10 @@ describe('isReactComponent', () => {
     expect(isReactComponent(VueRegisteredComponent)).toBe(false)
     expect(isReactComponent(VueSingleFileComponent)).toBe(false)
   })
+
+  it('returns false for blank input', () => {
+    expect(isReactComponent(false)).toBe(false)
+    expect(isReactComponent(null)).toBe(false)
+    expect(isReactComponent(undefined)).toBe(false)
+  })
 })


### PR DESCRIPTION
`isReactComponent` returned `true` for blank inputs (e.g. `undefined`), which could produce confusing error messages. E.g. from Vue if you had `components: {MyComponent: undefined}` (could be undefined because of e.g. a failing import) it would display a Vuera ReactWrapper error instead of the normal Vue "[Vue warn]: Unknown custom element" error.