### PR TITLE
Fix issue with vuera loading the incorrect component when you have two components registered with the same name

### DIFF
--- a/dist/vuera.cjs.js
+++ b/dist/vuera.cjs.js
@@ -459,7 +459,7 @@ var VuePlugin = {
 
         return _extends({}, acc, defineProperty({}, k, isReactComponent(v) ? VueResolver$$1(v) : v));
       }, {}) : mergedValue;
-      return Object.assign(parent, wrappedComponents);
+      return Object.assign(mergedValue, wrappedComponents);
     };
     Vue$$1.prototype.constructor.isVue = true;
   }

--- a/dist/vuera.es.js
+++ b/dist/vuera.es.js
@@ -453,7 +453,7 @@ var VuePlugin = {
 
         return _extends({}, acc, defineProperty({}, k, isReactComponent(v) ? VueResolver$$1(v) : v));
       }, {}) : mergedValue;
-      return Object.assign(parent, wrappedComponents);
+      return Object.assign(mergedValue, wrappedComponents);
     };
     Vue$$1.prototype.constructor.isVue = true;
   }

--- a/dist/vuera.iife.js
+++ b/dist/vuera.iife.js
@@ -456,7 +456,7 @@ var VuePlugin = {
 
         return _extends({}, acc, defineProperty({}, k, isReactComponent(v) ? VueResolver$$1(v) : v));
       }, {}) : mergedValue;
-      return Object.assign(parent, wrappedComponents);
+      return Object.assign(mergedValue, wrappedComponents);
     };
     Vue$$1.prototype.constructor.isVue = true;
   }

--- a/src/VuePlugin.js
+++ b/src/VuePlugin.js
@@ -22,7 +22,7 @@ export default {
             {}
           )
         : mergedValue
-      return Object.assign(parent, wrappedComponents)
+      return Object.assign(mergedValue, wrappedComponents)
     }
     Vue.prototype.constructor.isVue = true
   },


### PR DESCRIPTION
I faced a bug when I had two different Autocomplete components in my vue application registered under the same name. I traced the bug down to that the newComponentMergeStrategy was loading the incorrect component. 

I think the newComponentsMergeStrategy in vuera should not return the parent merged with the wrappedComponents, it should however return the mergedValue coming from the originalComponentsMergeStrategy merged with the wrappedComponents