### PR TITLE
[Needs tests/WIP] setVueInstanceOptions

### DIFF
--- a/dist/vuera.cjs.js
+++ b/dist/vuera.cjs.js
@@ -185,6 +185,11 @@ var wrapReactChildren = function wrapReactChildren(createElement, children) {
   });
 };
 
+var vueInstanceOptions = {};
+var setVueInstanceOptions = function setVueInstanceOptions(opts) {
+  vueInstanceOptions = opts;
+};
+
 var VueContainer = function (_React$Component) {
   inherits(VueContainer, _React$Component);
 
@@ -255,9 +260,10 @@ var VueContainer = function (_React$Component) {
 
       // `this` refers to Vue instance in the constructor
 
-      reactThisBinding.vueInstance = new Vue({
+      reactThisBinding.vueInstance = new Vue(_extends({
         el: targetElement,
-        data: props,
+        data: props
+      }, vueInstanceOptions, {
         render: function render(createElement) {
           return createElement(VUE_COMPONENT_NAME, {
             props: this.$data,
@@ -266,7 +272,7 @@ var VueContainer = function (_React$Component) {
         },
 
         components: (_components = {}, defineProperty(_components, VUE_COMPONENT_NAME, component), defineProperty(_components, 'vuera-internal-react-wrapper', ReactWrapper), _components)
-      });
+      }));
     }
   }, {
     key: 'updateVueComponent',
@@ -480,6 +486,7 @@ function babelReactResolver$$1(component, props, children) {
   return isReactComponent(component) ? React.createElement(component, props, children) : React.createElement(VueContainer, Object.assign({ component: component }, props), children);
 }
 
+exports.setVueInstanceOptions = setVueInstanceOptions;
 exports.ReactWrapper = ReactWrapper;
 exports.VueWrapper = VueContainer;
 exports.__vueraReactResolver = babelReactResolver$$1;

--- a/dist/vuera.es.js
+++ b/dist/vuera.es.js
@@ -179,6 +179,11 @@ var wrapReactChildren = function wrapReactChildren(createElement, children) {
   });
 };
 
+var vueInstanceOptions = {};
+var setVueInstanceOptions = function setVueInstanceOptions(opts) {
+  vueInstanceOptions = opts;
+};
+
 var VueContainer = function (_React$Component) {
   inherits(VueContainer, _React$Component);
 
@@ -249,9 +254,10 @@ var VueContainer = function (_React$Component) {
 
       // `this` refers to Vue instance in the constructor
 
-      reactThisBinding.vueInstance = new Vue({
+      reactThisBinding.vueInstance = new Vue(_extends({
         el: targetElement,
-        data: props,
+        data: props
+      }, vueInstanceOptions, {
         render: function render(createElement) {
           return createElement(VUE_COMPONENT_NAME, {
             props: this.$data,
@@ -260,7 +266,7 @@ var VueContainer = function (_React$Component) {
         },
 
         components: (_components = {}, defineProperty(_components, VUE_COMPONENT_NAME, component), defineProperty(_components, 'vuera-internal-react-wrapper', ReactWrapper), _components)
-      });
+      }));
     }
   }, {
     key: 'updateVueComponent',
@@ -474,4 +480,4 @@ function babelReactResolver$$1(component, props, children) {
   return isReactComponent(component) ? React.createElement(component, props, children) : React.createElement(VueContainer, Object.assign({ component: component }, props), children);
 }
 
-export { ReactWrapper, VueContainer as VueWrapper, babelReactResolver$$1 as __vueraReactResolver, VuePlugin, ReactResolver$$1 as VueInReact, VueResolver$$1 as ReactInVue };
+export { setVueInstanceOptions, ReactWrapper, VueContainer as VueWrapper, babelReactResolver$$1 as __vueraReactResolver, VuePlugin, ReactResolver$$1 as VueInReact, VueResolver$$1 as ReactInVue };

--- a/dist/vuera.iife.js
+++ b/dist/vuera.iife.js
@@ -182,6 +182,11 @@ var wrapReactChildren = function wrapReactChildren(createElement, children) {
   });
 };
 
+var vueInstanceOptions = {};
+var setVueInstanceOptions = function setVueInstanceOptions(opts) {
+  vueInstanceOptions = opts;
+};
+
 var VueContainer = function (_React$Component) {
   inherits(VueContainer, _React$Component);
 
@@ -252,9 +257,10 @@ var VueContainer = function (_React$Component) {
 
       // `this` refers to Vue instance in the constructor
 
-      reactThisBinding.vueInstance = new Vue({
+      reactThisBinding.vueInstance = new Vue(_extends({
         el: targetElement,
-        data: props,
+        data: props
+      }, vueInstanceOptions, {
         render: function render(createElement) {
           return createElement(VUE_COMPONENT_NAME, {
             props: this.$data,
@@ -263,7 +269,7 @@ var VueContainer = function (_React$Component) {
         },
 
         components: (_components = {}, defineProperty(_components, VUE_COMPONENT_NAME, component), defineProperty(_components, 'vuera-internal-react-wrapper', ReactWrapper), _components)
-      });
+      }));
     }
   }, {
     key: 'updateVueComponent',
@@ -477,6 +483,7 @@ function babelReactResolver$$1(component, props, children) {
   return isReactComponent(component) ? React.createElement(component, props, children) : React.createElement(VueContainer, Object.assign({ component: component }, props), children);
 }
 
+exports.setVueInstanceOptions = setVueInstanceOptions;
 exports.ReactWrapper = ReactWrapper;
 exports.VueWrapper = VueContainer;
 exports.__vueraReactResolver = babelReactResolver$$1;

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,11 @@
 import ReactWrapper from './wrappers/React'
-import VueWrapper from './wrappers/Vue'
+import VueWrapper, { setVueInstanceOptions } from './wrappers/Vue'
 import VuePlugin from './VuePlugin'
-import VueInReact, {
-  babelReactResolver as __vueraReactResolver,
-} from './resolvers/React'
+import VueInReact, { babelReactResolver as __vueraReactResolver } from './resolvers/React'
 import ReactInVue from './resolvers/Vue'
 
 export {
+  setVueInstanceOptions,
   ReactWrapper,
   VueWrapper,
   __vueraReactResolver,

--- a/src/wrappers/Vue.js
+++ b/src/wrappers/Vue.js
@@ -11,6 +11,11 @@ const wrapReactChildren = (createElement, children) =>
     },
   })
 
+let vueInstanceOptions = {}
+export const setVueInstanceOptions = opts => {
+  vueInstanceOptions = opts
+}
+
 export default class VueContainer extends React.Component {
   constructor (props) {
     super(props)
@@ -65,6 +70,7 @@ export default class VueContainer extends React.Component {
     reactThisBinding.vueInstance = new Vue({
       el: targetElement,
       data: props,
+      ...vueInstanceOptions,
       render (createElement) {
         return createElement(
           VUE_COMPONENT_NAME,


### PR DESCRIPTION
For https://github.com/akxcv/vuera/issues/82, adds a new export called `setVueInstanceOptions` which will allow the user to pass options to all their vue instances when used in a React app. Example:

```
import Vue from "vue";
import { setVueInstanceOptions } from "vuera";
import VueI18n from "vue-i18n";
import React from "react";
import { render } from "react-dom";
import { VsTable } from "example-vue-component-library";

Vue.use(VueI18n);
const i18n = new VueI18n({
  locale: "en",
  messages: {
    en: {
      no_data: "No data"
    }
  }
});

setVueInstanceOptions({
  i18n
});

render(
  <div>
    <VsTable data={[]} />
  </div>,
  document.querySelector("#app")
);
```