### PR TITLE
Add config class & Vue instance options

### DIFF
--- a/dist/vuera.cjs.js
+++ b/dist/vuera.cjs.js
@@ -185,6 +185,11 @@ var wrapReactChildren = function wrapReactChildren(createElement, children) {
   });
 };
 
+var vueInstanceOptions = {};
+var setVueInstanceOptions = function setVueInstanceOptions(opts) {
+  vueInstanceOptions = opts;
+};
+
 var VueContainer = function (_React$Component) {
   inherits(VueContainer, _React$Component);
 
@@ -255,9 +260,10 @@ var VueContainer = function (_React$Component) {
 
       // `this` refers to Vue instance in the constructor
 
-      reactThisBinding.vueInstance = new Vue({
+      reactThisBinding.vueInstance = new Vue(_extends({
         el: targetElement,
-        data: props,
+        data: props
+      }, vueInstanceOptions, {
         render: function render(createElement) {
           return createElement(VUE_COMPONENT_NAME, {
             props: this.$data,
@@ -266,7 +272,7 @@ var VueContainer = function (_React$Component) {
         },
 
         components: (_components = {}, defineProperty(_components, VUE_COMPONENT_NAME, component), defineProperty(_components, 'vuera-internal-react-wrapper', ReactWrapper), _components)
-      });
+      }));
     }
   }, {
     key: 'updateVueComponent',
@@ -480,6 +486,7 @@ function babelReactResolver$$1(component, props, children) {
   return isReactComponent(component) ? React.createElement(component, props, children) : React.createElement(VueContainer, Object.assign({ component: component }, props), children);
 }
 
+exports.setVueInstanceOptions = setVueInstanceOptions;
 exports.ReactWrapper = ReactWrapper;
 exports.VueWrapper = VueContainer;
 exports.__vueraReactResolver = babelReactResolver$$1;

--- a/dist/vuera.es.js
+++ b/dist/vuera.es.js
@@ -179,6 +179,11 @@ var wrapReactChildren = function wrapReactChildren(createElement, children) {
   });
 };
 
+var vueInstanceOptions = {};
+var setVueInstanceOptions = function setVueInstanceOptions(opts) {
+  vueInstanceOptions = opts;
+};
+
 var VueContainer = function (_React$Component) {
   inherits(VueContainer, _React$Component);
 
@@ -249,9 +254,10 @@ var VueContainer = function (_React$Component) {
 
       // `this` refers to Vue instance in the constructor
 
-      reactThisBinding.vueInstance = new Vue({
+      reactThisBinding.vueInstance = new Vue(_extends({
         el: targetElement,
-        data: props,
+        data: props
+      }, vueInstanceOptions, {
         render: function render(createElement) {
           return createElement(VUE_COMPONENT_NAME, {
             props: this.$data,
@@ -260,7 +266,7 @@ var VueContainer = function (_React$Component) {
         },
 
         components: (_components = {}, defineProperty(_components, VUE_COMPONENT_NAME, component), defineProperty(_components, 'vuera-internal-react-wrapper', ReactWrapper), _components)
-      });
+      }));
     }
   }, {
     key: 'updateVueComponent',
@@ -474,4 +480,4 @@ function babelReactResolver$$1(component, props, children) {
   return isReactComponent(component) ? React.createElement(component, props, children) : React.createElement(VueContainer, Object.assign({ component: component }, props), children);
 }
 
-export { ReactWrapper, VueContainer as VueWrapper, babelReactResolver$$1 as __vueraReactResolver, VuePlugin, ReactResolver$$1 as VueInReact, VueResolver$$1 as ReactInVue };
+export { setVueInstanceOptions, ReactWrapper, VueContainer as VueWrapper, babelReactResolver$$1 as __vueraReactResolver, VuePlugin, ReactResolver$$1 as VueInReact, VueResolver$$1 as ReactInVue };

--- a/dist/vuera.iife.js
+++ b/dist/vuera.iife.js
@@ -182,6 +182,11 @@ var wrapReactChildren = function wrapReactChildren(createElement, children) {
   });
 };
 
+var vueInstanceOptions = {};
+var setVueInstanceOptions = function setVueInstanceOptions(opts) {
+  vueInstanceOptions = opts;
+};
+
 var VueContainer = function (_React$Component) {
   inherits(VueContainer, _React$Component);
 
@@ -252,9 +257,10 @@ var VueContainer = function (_React$Component) {
 
       // `this` refers to Vue instance in the constructor
 
-      reactThisBinding.vueInstance = new Vue({
+      reactThisBinding.vueInstance = new Vue(_extends({
         el: targetElement,
-        data: props,
+        data: props
+      }, vueInstanceOptions, {
         render: function render(createElement) {
           return createElement(VUE_COMPONENT_NAME, {
             props: this.$data,
@@ -263,7 +269,7 @@ var VueContainer = function (_React$Component) {
         },
 
         components: (_components = {}, defineProperty(_components, VUE_COMPONENT_NAME, component), defineProperty(_components, 'vuera-internal-react-wrapper', ReactWrapper), _components)
-      });
+      }));
     }
   }, {
     key: 'updateVueComponent',
@@ -477,6 +483,7 @@ function babelReactResolver$$1(component, props, children) {
   return isReactComponent(component) ? React.createElement(component, props, children) : React.createElement(VueContainer, Object.assign({ component: component }, props), children);
 }
 
+exports.setVueInstanceOptions = setVueInstanceOptions;
 exports.ReactWrapper = ReactWrapper;
 exports.VueWrapper = VueContainer;
 exports.__vueraReactResolver = babelReactResolver$$1;

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,7 @@
+export function defaultConfig () {
+  return {
+    vueInstanceOptions: {},
+  }
+}
+
+export default defaultConfig()

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,11 @@
 import ReactWrapper from './wrappers/React'
-import VueWrapper from './wrappers/Vue'
+import VueWrapper, { setVueInstanceOptions } from './wrappers/Vue'
 import VuePlugin from './VuePlugin'
-import VueInReact, {
-  babelReactResolver as __vueraReactResolver,
-} from './resolvers/React'
+import VueInReact, { babelReactResolver as __vueraReactResolver } from './resolvers/React'
 import ReactInVue from './resolvers/Vue'
 
 export {
+  setVueInstanceOptions,
   ReactWrapper,
   VueWrapper,
   __vueraReactResolver,

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import ReactWrapper from './wrappers/React'
 import VueWrapper, { setVueInstanceOptions } from './wrappers/Vue'
 import VuePlugin from './VuePlugin'
 import VueInReact, { babelReactResolver as __vueraReactResolver } from './resolvers/React'
+import config from './config'
 import ReactInVue from './resolvers/Vue'
 
 export {
@@ -12,4 +13,5 @@ export {
   VuePlugin,
   VueInReact,
   ReactInVue,
+  config,
 }

--- a/src/wrappers/Vue.js
+++ b/src/wrappers/Vue.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import Vue from 'vue'
 import ReactWrapper from './React'
+import { config } from '../../src'
 
 const VUE_COMPONENT_NAME = 'vuera-internal-component-name'
 
@@ -10,11 +11,6 @@ const wrapReactChildren = (createElement, children) =>
       component: () => <div>{children}</div>,
     },
   })
-
-let vueInstanceOptions = {}
-export const setVueInstanceOptions = opts => {
-  vueInstanceOptions = opts
-}
 
 export default class VueContainer extends React.Component {
   constructor (props) {
@@ -70,7 +66,7 @@ export default class VueContainer extends React.Component {
     reactThisBinding.vueInstance = new Vue({
       el: targetElement,
       data: props,
-      ...vueInstanceOptions,
+      ...config.vueInstanceOptions,
       render (createElement) {
         return createElement(
           VUE_COMPONENT_NAME,

--- a/src/wrappers/Vue.js
+++ b/src/wrappers/Vue.js
@@ -11,6 +11,11 @@ const wrapReactChildren = (createElement, children) =>
     },
   })
 
+let vueInstanceOptions = {}
+export const setVueInstanceOptions = opts => {
+  vueInstanceOptions = opts
+}
+
 export default class VueContainer extends React.Component {
   constructor (props) {
     super(props)
@@ -65,6 +70,7 @@ export default class VueContainer extends React.Component {
     reactThisBinding.vueInstance = new Vue({
       el: targetElement,
       data: props,
+      ...vueInstanceOptions,
       render (createElement) {
         return createElement(
           VUE_COMPONENT_NAME,

--- a/tests/config-test.js
+++ b/tests/config-test.js
@@ -1,0 +1,7 @@
+import { config } from '../src'
+
+describe('config', () => {
+  it('defaults to an empty vueInstanceOptions', () => {
+    expect(config.vueInstanceOptions).toEqual({})
+  })
+})

--- a/tests/fixtures/VueInstanceOptionsComponent.js
+++ b/tests/fixtures/VueInstanceOptionsComponent.js
@@ -1,0 +1,23 @@
+export const Plugin = {}
+Plugin.install = function (Vue) {
+  Vue.mixin({
+    beforeCreate () {
+      const options = this.$options
+      if (options.foo) {
+        this.$foo = options.foo
+      } else if (options.parent && options.parent.$foo) {
+        this.$foo = options.parent.$foo
+      }
+    },
+  })
+}
+
+export default {
+  props: [],
+  render (createElement) {
+    return createElement('div', [
+      createElement('span', this.$options.parent.$options.bar),
+      createElement('span', this.$foo),
+    ])
+  },
+}

--- a/tests/wrappers/VueWrapper-test.js
+++ b/tests/wrappers/VueWrapper-test.js
@@ -1,7 +1,9 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { VueWrapper } from '../../src'
+import Vue from 'vue'
+import { VueWrapper, config } from '../../src'
 import VueComponent from '../fixtures/VueComponent'
+import VueInstanceOptionsComponent, { Plugin } from '../fixtures/VueInstanceOptionsComponent'
 import VueRegisteredComponent from '../fixtures/VueRegisteredComponent'
 import VueSingleFileComponent from '../fixtures/VueSingleFileComponent.vue'
 
@@ -203,6 +205,21 @@ describe('VueInReact', () => {
           </div>`
         )
       )
+    })
+  })
+
+  describe('config', () => {
+    afterEach(() => {
+      config.vueInstanceOptions = {}
+    })
+
+    it('adds vue instance options', () => {
+      Vue.use(Plugin)
+
+      config.vueInstanceOptions = { foo: 'New message!', bar: 'Other message' }
+      makeReactInstanceWithVueComponent(VueInstanceOptionsComponent)
+      expect(document.body.innerHTML).toContain('New message!')
+      expect(document.body.innerHTML).toContain('Other message')
     })
   })
 })


### PR DESCRIPTION
This builds off of https://github.com/akxcv/vuera/pull/83 by adding a config object for the options. As well, it adds tests for the usage. 

@akxcv I didn't update the `dist/` files, but I can do that if this looks good.

Would close https://github.com/akxcv/vuera/issues/82.