### PR TITLE
Support vue component file that exports Vue.extend.

### DIFF
--- a/dist/vuera.cjs.js
+++ b/dist/vuera.cjs.js
@@ -411,7 +411,7 @@ function isReactComponent(component) {
     return false;
   }
 
-  return !(typeof component === 'function' && component.prototype && component.prototype.constructor.super && component.prototype.constructor.super.isVue);
+  return !(typeof component === 'function' && component.prototype && (component.prototype.constructor.super && component.prototype.constructor.super.isVue || component.prototype instanceof Vue));
 }
 
 function isReactForwardReference(component) {

--- a/dist/vuera.es.js
+++ b/dist/vuera.es.js
@@ -405,7 +405,7 @@ function isReactComponent(component) {
     return false;
   }
 
-  return !(typeof component === 'function' && component.prototype && component.prototype.constructor.super && component.prototype.constructor.super.isVue);
+  return !(typeof component === 'function' && component.prototype && (component.prototype.constructor.super && component.prototype.constructor.super.isVue || component.prototype instanceof Vue));
 }
 
 function isReactForwardReference(component) {

--- a/dist/vuera.iife.js
+++ b/dist/vuera.iife.js
@@ -408,7 +408,7 @@ function isReactComponent(component) {
     return false;
   }
 
-  return !(typeof component === 'function' && component.prototype && component.prototype.constructor.super && component.prototype.constructor.super.isVue);
+  return !(typeof component === 'function' && component.prototype && (component.prototype.constructor.super && component.prototype.constructor.super.isVue || component.prototype instanceof Vue));
 }
 
 function isReactForwardReference(component) {

--- a/src/utils/isReactComponent.js
+++ b/src/utils/isReactComponent.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 
-export default function isReactComponent(component) {
+export default function isReactComponent (component) {
   if (typeof component === 'object' && !isReactForwardReference(component)) {
     return false
   }
@@ -13,6 +13,6 @@ export default function isReactComponent(component) {
   )
 }
 
-function isReactForwardReference(component) {
+function isReactForwardReference (component) {
   return component.$$typeof && component.$$typeof.toString() === 'Symbol(react.forward_ref)'
 }

--- a/src/utils/isReactComponent.js
+++ b/src/utils/isReactComponent.js
@@ -1,4 +1,6 @@
-export default function isReactComponent (component) {
+import Vue from 'vue'
+
+export default function isReactComponent(component) {
   if (typeof component === 'object' && !isReactForwardReference(component)) {
     return false
   }
@@ -6,11 +8,11 @@ export default function isReactComponent (component) {
   return !(
     typeof component === 'function' &&
     component.prototype &&
-    component.prototype.constructor.super &&
-    component.prototype.constructor.super.isVue
+    ((component.prototype.constructor.super && component.prototype.constructor.super.isVue) ||
+      component.prototype instanceof Vue)
   )
 }
 
-function isReactForwardReference (component) {
+function isReactForwardReference(component) {
   return component.$$typeof && component.$$typeof.toString() === 'Symbol(react.forward_ref)'
 }


### PR DESCRIPTION
Normally, vue component js file exports an options object. For example: export default {props:{title:""}}. In some cases, vue component js file needs to exports Vue.extend. For example: export default Vue.extend(options). Vue natually support it. This fix is used to support Vue.extend when using Vue components in React.