### PR TITLE
fix: remove useless div

### DIFF
--- a/dist/vuera.cjs.js
+++ b/dist/vuera.cjs.js
@@ -176,7 +176,7 @@ var wrapReactChildren = function wrapReactChildren(createElement, children) {
     props: {
       component: function component() {
         return React.createElement(
-          'div',
+          React.Fragment,
           null,
           children
         );

--- a/dist/vuera.es.js
+++ b/dist/vuera.es.js
@@ -170,7 +170,7 @@ var wrapReactChildren = function wrapReactChildren(createElement, children) {
     props: {
       component: function component() {
         return React.createElement(
-          'div',
+          React.Fragment,
           null,
           children
         );

--- a/dist/vuera.iife.js
+++ b/dist/vuera.iife.js
@@ -173,7 +173,7 @@ var wrapReactChildren = function wrapReactChildren(createElement, children) {
     props: {
       component: function component() {
         return React.createElement(
-          'div',
+          React.Fragment,
           null,
           children
         );

--- a/src/wrappers/Vue.js
+++ b/src/wrappers/Vue.js
@@ -8,7 +8,7 @@ const VUE_COMPONENT_NAME = 'vuera-internal-component-name'
 const wrapReactChildren = (createElement, children) =>
   createElement('vuera-internal-react-wrapper', {
     props: {
-      component: () => <div>{children}</div>,
+      component: () => <React.Fragment>{children}</React.Fragment>,
     },
   })
 


### PR DESCRIPTION
🤡    fix: Replace the useless `div` with `React.Fragment` 🚀